### PR TITLE
Unsupported method/code error message improvements

### DIFF
--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -607,7 +607,7 @@ namespace Neo.Compiler.MSIL
             }
 
             if (calltype == 0)
-                throw new Exception("unknown call:" + src.tokenMethod + "\r\n   in: " + to.name + "\r\n");
+                throw new Exception("unknown call: " + src.tokenMethod + "\r\n   in: " + to.name + "\r\n");
             var md = src.tokenUnknown as Mono.Cecil.MethodReference;
             var pcount = md.Parameters.Count;
 

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -607,7 +607,7 @@ namespace Neo.Compiler.MSIL
             }
 
             if (calltype == 0)
-                throw new Exception("unknown call:" + src.tokenMethod);
+                throw new Exception("unknown call:" + src.tokenMethod + "\r\n   in: " + to.name + "\r\n");
             var md = src.tokenUnknown as Mono.Cecil.MethodReference;
             var pcount = md.Parameters.Count;
 

--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -312,7 +312,15 @@ namespace Neo.Compiler.MSIL
                     //}
                     //else
                     {
-                        var addr = addrconv[c.srcaddr];
+                        try
+                        {
+                            var addr = addrconv[c.srcaddr];
+                        }
+                        catch
+                        {
+                            throw new Exception("cannot convert addr in: " + to.name + "\r\n");
+                        }
+
                         Int16 addroff = (Int16)(addr - c.addr);
                         c.bytes = BitConverter.GetBytes(addroff);
                         c.needfix = false;

--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -799,7 +799,7 @@ namespace Neo.Compiler.MSIL
                             }
                             else
                             {
-                                throw new Exception("not support type Ldsfld");
+                                throw new Exception("not support type Ldsfld\r\n   in: " + to.name + "\r\n");
                             }
                             break;
                         }
@@ -838,10 +838,10 @@ namespace Neo.Compiler.MSIL
                     break;
                 default:
 #if WITHPDB
-                    logger.Log("unsupported instruction " + src.code);
+                    logger.Log("unsupported instruction " + src.code + "\r\n   in: " + to.name + "\r\n");
                     break;
 #else
-                    throw new Exception("unsupported instruction " + src.code);
+                    throw new Exception("unsupported instruction " + src.code + "\r\n   in: " + to.name + "\r\n");
 #endif
             }
 


### PR DESCRIPTION
While converting a smart contract from .dll to .avm the converter was displaying errors but no information about where in the code the error was found. By adding the To method names to the messages in the exceptions I was able to find the lines of code causing the problems