### PR TITLE
declare addr outside of try block to be in scope for offset subtraction

### DIFF
--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -326,9 +326,10 @@ namespace Neo.Compiler.MSIL
                     //}
                     //else
                     {
+                        var addr = 0;
                         try
                         {
-                            var addr = addrconv[c.srcaddr];
+                            addr = addrconv[c.srcaddr];
                         }
                         catch
                         {


### PR DESCRIPTION
Fixed a bug where address offsets were being incorrectly calculated by use of addr variable declared inside of try block and out-of-scope of subtraction operation.