### PR TITLE
Support byte values in neoj

### DIFF
--- a/neoj/JVM/Converter_Mutli.cs
+++ b/neoj/JVM/Converter_Mutli.cs
@@ -316,6 +316,7 @@ namespace Neo.Compiler.JVM
                     name == "java.lang.String::valueOf" ||
                     name == "java.lang.Long::valueOf" ||
                     name == "java.lang.Integer::valueOf" ||
+		    name == "java.lang.Byte::valueOf" ||
                     name == "java.math.BigInteger::toByteArray")
                 {
                     //donothing


### PR DESCRIPTION
Hi,

This small change should enable byte as return values. For example the following code:

```
import org.neo.smartcontract.framework.SmartContract;

public class Test extends SmartContract
{
    public static final byte a = 0x0a;

    public static Object Main()
    {
	return a;
    }
}
```

should now compile