### PR TITLE
Debug map generation support for Neon.exe

### DIFF
--- a/neon/Debugger/DebugInfo.cs
+++ b/neon/Debugger/DebugInfo.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace Neo.Compiler.Debugger
+{
+    public static class DebugInfo
+    {
+        public static MyJson.JsonNode_Object ExportDebugInfo(string avmName, NeoModule module)
+        {
+            var outjson = new MyJson.JsonNode_Object();
+
+            var debugMap = new List<DebugMapEntry>();
+            DebugMapEntry currentDebugEntry = null;
+
+            var fileMap = new Dictionary<string, int>();
+
+            List<byte> bytes = new List<byte>();
+
+            foreach (var c in module.total_Codes.Values)
+            {
+                if (c.debugcode != null && c.debugline > 0 && c.debugline < 2000)
+                {
+                    var previousDebugEntry = currentDebugEntry;
+
+                    currentDebugEntry = new DebugMapEntry();
+                    if (previousDebugEntry != null)
+                    {
+                        currentDebugEntry.startOfs = previousDebugEntry.endOfs + 1;
+                        currentDebugEntry.endOfs = bytes.Count;
+                    }
+                    else
+                    {
+                        currentDebugEntry.startOfs = 0;
+                        currentDebugEntry.endOfs = bytes.Count;
+                    }
+                    currentDebugEntry.url = c.debugcode;
+                    currentDebugEntry.line = c.debugline;
+
+                    if (!fileMap.ContainsKey(c.debugcode))
+                    {
+                        fileMap[c.debugcode] = fileMap.Count + 1;
+                    }
+
+                    debugMap.Add(currentDebugEntry);
+                }
+                else
+                if (currentDebugEntry != null)
+                {
+                    currentDebugEntry.endOfs = bytes.Count;
+                }
+                bytes.Add((byte)c.code);
+                if (c.bytes != null)
+                    for (var i = 0; i < c.bytes.Length; i++)
+                    {
+                        bytes.Add(c.bytes[i]);
+                    }
+
+            }
+
+            string compilerName = System.AppDomain.CurrentDomain.FriendlyName.ToLowerInvariant();
+            var version = Assembly.GetEntryAssembly().GetName().Version.ToString();
+
+            var avmInfo = new MyJson.JsonNode_Object();
+            avmInfo.Add("name", new MyJson.JsonNode_ValueString(avmName));
+            //avmInfo.Add("hash", new MyJson.JsonNode_ValueString(hash));
+
+            var compilerInfo = new MyJson.JsonNode_Object();
+            compilerInfo.Add("name", new MyJson.JsonNode_ValueString(compilerName));
+            compilerInfo.Add("version", new MyJson.JsonNode_ValueString(version));
+
+            var fileInfo = new MyJson.JsonNode_Array();
+            foreach (var entry in fileMap)
+            {
+                var fileEntry = new MyJson.JsonNode_Object();
+                fileEntry.Add("id", new MyJson.JsonNode_ValueNumber(entry.Value));
+                fileEntry.Add("url", new MyJson.JsonNode_ValueString(entry.Key));
+                fileInfo.AddArrayValue(fileEntry);
+            }
+
+            var mapInfo = new MyJson.JsonNode_Array();
+            foreach (var entry in debugMap)
+            {
+                if (!fileMap.ContainsKey(entry.url))
+                {
+                    continue;
+                }
+
+                var fileID = fileMap[entry.url];
+
+                var mapEntry = new MyJson.JsonNode_Object();
+                mapEntry.Add("start", new MyJson.JsonNode_ValueNumber(entry.startOfs));
+                mapEntry.Add("end", new MyJson.JsonNode_ValueNumber(entry.endOfs));
+                mapEntry.Add("file", new MyJson.JsonNode_ValueNumber(fileID));
+                mapEntry.Add("line", new MyJson.JsonNode_ValueNumber(entry.line));
+                mapInfo.AddArrayValue(mapEntry);
+            }
+
+            outjson["avm"] = avmInfo;
+            outjson["compiler"] = compilerInfo;
+            outjson["files"] = fileInfo;
+            outjson["map"] = mapInfo;
+
+            return outjson;
+        }
+
+    }
+}

--- a/neon/Debugger/NeoDebugMap.cs
+++ b/neon/Debugger/NeoDebugMap.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Neo.Compiler.Debugger
+{
+    public class DebugMapEntry
+    {
+        public string url;
+        public int line;
+
+        public int startOfs;
+        public int endOfs;
+
+        public override string ToString()
+        {
+            return "Line "+this.line+" at "+url;
+        }
+    }
+
+    public class NeoMapFile
+    {
+        private List<DebugMapEntry> _entries = new List<DebugMapEntry>();
+        public IEnumerable<DebugMapEntry> Entries { get { return _entries; } }
+
+        public string contractName { get; private set; }
+
+        public IEnumerable<string> FileNames => _fileNames;
+        private HashSet<string> _fileNames = new HashSet<string>();
+
+        /// <summary>
+        /// Calculates the source code line that maps to the specificed script offset.
+        /// </summary>
+        public int ResolveLine(int ofs, out string filePath)
+        {
+            foreach (var entry in this.Entries)
+            {
+                if (ofs >= entry.startOfs && ofs <= entry.endOfs)
+                {
+                    filePath = entry.url;
+                    return entry.line;
+                }
+            }
+
+            throw new Exception("Offset cannot be mapped");
+        }
+
+        /// <summary>
+        /// Calculates the script offset that maps to the specificed source code line 
+        /// </summary>
+        public int ResolveStartOffset(int line, string filePath)
+        {
+            foreach (var entry in this.Entries)
+            {
+                if (entry.line == line && entry.url == filePath)
+                {
+                    return entry.startOfs;
+                }
+            }
+
+            throw new Exception("Line cannot be mapped");
+        }
+
+        public int ResolveEndOffset(int line, string filePath)
+        {
+            foreach (var entry in this.Entries)
+            {
+                if (entry.line == line && entry.url == filePath)
+                {
+                    return entry.endOfs;
+                }
+            }
+
+            throw new Exception("Line cannot be mapped");
+        }
+
+    }
+
+}

--- a/neon/Debugger/NeoDisassembler.cs
+++ b/neon/Debugger/NeoDisassembler.cs
@@ -1,0 +1,484 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Neo.VM;
+
+namespace Neo.Compiler.Debugger
+{
+    public class DisassembleEntry
+    {
+        public int startOfs;
+        public int endOfs;
+        public string name;
+        public OpCode opcode;
+        public byte[] data;
+        public string comment;
+    }
+
+    public struct DisassembleLocation
+    {
+        public string fileName;
+        public int line;
+    }
+
+    public class DisassembleException : Exception
+    {
+        public DisassembleException(string msg) : base(msg)
+        {
+
+        }
+    }
+
+    public class AVMDisassemble
+    {
+        private List<DisassembleEntry> _lines;
+        public IEnumerable<DisassembleEntry> lines { get { return _lines; } }
+
+        public AVMDisassemble(List<DisassembleEntry> lines)
+        {
+            this._lines = lines;
+        }
+
+        public int ResolveLine(int ofs)
+        {
+            int i = 0;
+            foreach (var line in lines)
+            {
+                if (ofs >= line.startOfs && ofs <= line.endOfs)
+                {
+                    return i;
+                }
+
+                i++;
+            }
+
+            throw new Exception("Offset cannot be mapped");
+        }
+
+        public int ResolveOffset(int line)
+        {
+            if (line < 0 || line >= _lines.Count)
+            {
+                throw new Exception("Line cannot be mapped");
+            }
+
+            return _lines[line].startOfs;
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            //sb.AppendLine(FormattingUtils.OutputLine("Offset", "Opcode", "Comment"));
+            foreach (var entry in this.lines)
+            {
+                string opStr = entry.name;
+                string hintStr = entry.comment;
+
+                if (!string.IsNullOrEmpty(hintStr))
+                {
+                    hintStr = "// " + hintStr;
+                }
+
+                sb.AppendLine(opStr.PadRight(8, ' ') + hintStr);
+            }
+
+            return sb.ToString();
+        }
+    }
+
+    public static class NeoDisassembler
+    {
+        private static Dictionary<OpCode, string> hints = null;
+
+        private static void InitHints()
+        {
+            if (hints != null)
+            {
+                return;
+            }
+
+            hints = new Dictionary<OpCode, string>();
+            // Constants
+            hints[OpCode.PUSH0] = "An empty array of bytes is pushed onto the stack.";
+            hints[OpCode.PUSHF] = hints[OpCode.PUSH0];
+            hints[OpCode.PUSHBYTES1] = /*0x01-0x4B*/ "The next opcode bytes is data to be pushed onto the stack";
+            hints[OpCode.PUSHBYTES75] = "";
+            hints[OpCode.PUSHDATA1] = "The next byte contains the number of bytes to be pushed onto the stack.";
+            hints[OpCode.PUSHDATA2] = "The next two bytes contain the number of bytes to be pushed onto the stack.";
+            hints[OpCode.PUSHDATA4] = "The next four bytes contain the number of bytes to be pushed onto the stack.";
+            hints[OpCode.PUSHM1] = "The number -1 is pushed onto the stack.";
+            hints[OpCode.PUSH1] = "The number 1 is pushed onto the stack.";
+            hints[OpCode.PUSHT] = hints[OpCode.PUSH1];
+            hints[OpCode.PUSH2] = "The number 2 is pushed onto the stack.";
+            hints[OpCode.PUSH3] = "The number 3 is pushed onto the stack.";
+            hints[OpCode.PUSH4] = "The number 4 is pushed onto the stack.";
+            hints[OpCode.PUSH5] = "The number 5 is pushed onto the stack.";
+            hints[OpCode.PUSH6] = "The number 6 is pushed onto the stack.";
+            hints[OpCode.PUSH7] = "The number 7 is pushed onto the stack.";
+            hints[OpCode.PUSH8] = "The number 8 is pushed onto the stack.";
+            hints[OpCode.PUSH9] = "The number 9 is pushed onto the stack.";
+            hints[OpCode.PUSH10] = "The number 10 is pushed onto the stack.";
+            hints[OpCode.PUSH11] = "The number 11 is pushed onto the stack.";
+            hints[OpCode.PUSH12] = "The number 12 is pushed onto the stack.";
+            hints[OpCode.PUSH13] = "The number 13 is pushed onto the stack.";
+            hints[OpCode.PUSH14] = "The number 14 is pushed onto the stack.";
+            hints[OpCode.PUSH15] = "The number 15 is pushed onto the stack.";
+            hints[OpCode.PUSH16] = "The number 16 is pushed onto the stack.";
+
+
+            // Flow control
+            hints[OpCode.NOP] = "Does nothing.";
+            hints[OpCode.JMP] = "";
+            hints[OpCode.JMPIF] = "";
+            hints[OpCode.JMPIFNOT] = "";
+            hints[OpCode.CALL] = "";
+            hints[OpCode.RET] = "";
+            hints[OpCode.APPCALL] = "";
+            hints[OpCode.SYSCALL] = "";
+            hints[OpCode.TAILCALL] = "";
+
+
+            // Stack
+            hints[OpCode.DUPFROMALTSTACK] = "";
+            hints[OpCode.TOALTSTACK] = "Puts the input onto the top of the alt stack. Removes it from the main stack.";
+            hints[OpCode.FROMALTSTACK] = "Puts the input onto the top of the main stack. Removes it from the alt stack.";
+            hints[OpCode.XDROP] = "";
+            hints[OpCode.XSWAP] = "";
+            hints[OpCode.XTUCK] = "";
+            hints[OpCode.DEPTH] = "Puts the number of stack items onto the stack.";
+            hints[OpCode.DROP] = "Removes the top stack item.";
+            hints[OpCode.DUP] = "Duplicates the top stack item.";
+            hints[OpCode.NIP] = "Removes the second-to-top stack item.";
+            hints[OpCode.OVER] = "Copies the second-to-top stack item to the top.";
+            hints[OpCode.PICK] = "The item in back in the stack is copied to the top.";
+            hints[OpCode.ROLL] = "The item in back in the stack is moved to the top.";
+            hints[OpCode.ROT] = "The top three items on the stack are rotated to the left.";
+            hints[OpCode.SWAP] = "The top two items on the stack are swapped.";
+            hints[OpCode.TUCK] = "The item at the top of the stack is copied and inserted before the second-to-top item.";
+
+
+            // Splice
+            hints[OpCode.CAT] = "Concatenates two strings.";
+            hints[OpCode.SUBSTR] = "Returns a section of a string.";
+            hints[OpCode.LEFT] = "Keeps only characters left of the specified point in a string.";
+            hints[OpCode.RIGHT] = "Keeps only characters right of the specified point in a string.";
+            hints[OpCode.SIZE] = "Returns the length of the input string.";
+
+
+            // Bitwise logic
+            hints[OpCode.INVERT] = "Flips all of the bits in the input.";
+            hints[OpCode.AND] = "Boolean and between each bit in the inputs.";
+            hints[OpCode.OR] = "Boolean or between each bit in the inputs.";
+            hints[OpCode.XOR] = "Boolean exclusive or between each bit in the inputs.";
+            hints[OpCode.EQUAL] = "Returns 1 if the inputs are exactly equal, 0 otherwise.";
+            //OP_EQUALVERIFY = 0x88, // Same as OP_EQUAL, but runs OP_VERIFY afterward.
+            //OP_RESERVED1 = 0x89, // Transaction is invalid unless occuring in an unexecuted OP_IF branch
+            //OP_RESERVED2 = 0x8A, // Transaction is invalid unless occuring in an unexecuted OP_IF branch
+
+
+            // Arithmetic
+            // Note: Arithmetic inputs are limited to signed 32-bit integers, but may overflow their output.
+            hints[OpCode.INC] = "1 is added to the input.";
+            hints[OpCode.DEC] = "1 is subtracted from the input.";
+            hints[OpCode.SIGN] = "";
+            hints[OpCode.NEGATE] = "The sign of the input is flipped.";
+            hints[OpCode.ABS] = "The input is made positive.";
+            hints[OpCode.NOT] = "If the input is 0 or 1, it is flipped. Otherwise the output will be 0.";
+            hints[OpCode.NZ] = "Returns 0 if the input is 0. 1 otherwise.";
+            hints[OpCode.ADD] = "a is added to b.";
+            hints[OpCode.SUB] = "b is subtracted from a.";
+            hints[OpCode.MUL] = "a is multiplied by b.";
+            hints[OpCode.DIV] = "a is divided by b.";
+            hints[OpCode.MOD] = "Returns the remainder after dividing a by b.";
+            hints[OpCode.SHL] = "Shifts a left b bits, preserving sign.";
+            hints[OpCode.SHR] = "Shifts a right b bits, preserving sign.";
+            hints[OpCode.BOOLAND] = "If both a and b are not 0, the output is 1. Otherwise 0.";
+            hints[OpCode.BOOLOR] = "If a or b is not 0, the output is 1. Otherwise 0.";
+            hints[OpCode.NUMEQUAL] = "Returns 1 if the numbers are equal, 0 otherwise.";
+            hints[OpCode.NUMNOTEQUAL] = "Returns 1 if the numbers are not equal, 0 otherwise.";
+            hints[OpCode.LT] = "Returns 1 if a is less than b, 0 otherwise.";
+            hints[OpCode.GT] = "Returns 1 if a is greater than b, 0 otherwise.";
+            hints[OpCode.LTE] = "Returns 1 if a is less than or equal to b, 0 otherwise.";
+            hints[OpCode.GTE] = "Returns 1 if a is greater than or equal to b, 0 otherwise.";
+            hints[OpCode.MIN] = "Returns the smaller of a and b.";
+            hints[OpCode.MAX] = "Returns the larger of a and b.";
+            hints[OpCode.WITHIN] = "Returns 1 if x is within the specified range (left-inclusive), 0 otherwise.";
+
+
+            // Crypto
+            //hints[OpCode.RIPEMD160 = 0xA6, // The input is hashed using RIPEMD-160.
+            hints[OpCode.SHA1] = ""; // The input is hashed using SHA-1.
+            hints[OpCode.SHA256] = ""; // The input is hashed using SHA-256.
+            hints[OpCode.HASH160] = "";
+            hints[OpCode.HASH256] = "";
+            hints[OpCode.CHECKSIG] = "";
+            hints[OpCode.CHECKMULTISIG] = "";
+
+
+            // Array
+            hints[OpCode.ARRAYSIZE] = "";
+            hints[OpCode.PACK] = "";
+            hints[OpCode.UNPACK] = "";
+            hints[OpCode.PICKITEM] = "Pops index and array from stack, then push the item in the array index to the stack";
+            hints[OpCode.SETITEM] = "Pops newItem, index and array from stack, then copy the newItem to the array value at index";
+            hints[OpCode.NEWARRAY] = "Pops size from stack and creates a new array with that size, and pushes the array into the stack";
+            hints[OpCode.NEWSTRUCT] = "用作值類型";
+
+
+            // Exceptions
+            hints[OpCode.THROW] = "";
+            hints[OpCode.THROWIFNOT] = "";
+        }
+
+        public static byte[] ReadVarBytes(this BinaryReader reader, int max = 0X7fffffc7)
+        {
+            return reader.ReadBytes((int)reader.ReadVarInt((ulong)max));
+        }
+
+
+        public static ulong ReadVarInt(this BinaryReader reader, ulong max = ulong.MaxValue)
+        {
+            byte fb = reader.ReadByte();
+            ulong value;
+            if (fb == 0xFD)
+                value = reader.ReadUInt16();
+            else if (fb == 0xFE)
+                value = reader.ReadUInt32();
+            else if (fb == 0xFF)
+                value = reader.ReadUInt64();
+            else
+                value = fb;
+            if (value > max) throw new FormatException();
+            return value;
+        }
+
+        public static AVMDisassemble Disassemble(byte[] script)
+        {
+            InitHints();
+
+            var output = new List<DisassembleEntry>();
+
+            using (var stream = new MemoryStream(script))
+            {
+                using (var reader = new BinaryReader(stream))
+                {
+                    while (reader.BaseStream.Position != reader.BaseStream.Length)
+                    {
+                        var entry = new DisassembleEntry();
+                        output.Add(entry);
+
+                        entry.startOfs = (int)reader.BaseStream.Position;
+
+                        var opcode = (OpCode)reader.ReadByte();
+
+                        entry.opcode = opcode;
+                        entry.name = opcode.ToString();
+
+                        entry.comment = hints.ContainsKey(opcode) ? hints[opcode] : "";
+
+                        if (opcode >= OpCode.PUSHBYTES1 && opcode <= OpCode.PUSHBYTES75)
+                        {
+                            var len = (byte)opcode;
+                            entry.data = reader.ReadBytes(len);
+                            entry.name = "PUSHBYTES" + len;
+                            entry.comment = "Pushes " + len + " bytes into the stack: $$";
+                        }
+                        else
+                            switch (opcode)
+                            {
+                                // Push value
+                                //case OpCode.PUSH0:
+
+                                case OpCode.PUSHDATA1:
+                                    {
+                                        var len = reader.ReadByte();
+                                        entry.data = reader.ReadBytes(len);
+                                        entry.comment = "Pushes " + len + " bytes into the stack: $$";
+                                        break;
+                                    }
+
+                                case OpCode.PUSHDATA2:
+                                    {
+                                        var len = reader.ReadUInt16();
+                                        entry.data = reader.ReadBytes(len);
+                                        entry.comment = "Pushes " + len + " bytes into the stack: $$";
+                                        break;
+                                    }
+
+
+                                case OpCode.PUSHDATA4:
+                                    {
+                                        var len = reader.ReadInt32();
+                                        entry.data = reader.ReadBytes(len);
+                                        entry.comment = "Pushes " + len + " bytes into the stack: $$";
+                                        break;
+                                    }
+
+                                /*case OpCode.PUSHM1:
+                                case OpCode.PUSH1:
+                                case OpCode.PUSH2:
+                                case OpCode.PUSH3:
+                                case OpCode.PUSH4:
+                                case OpCode.PUSH5:
+                                case OpCode.PUSH6:
+                                case OpCode.PUSH7:
+                                case OpCode.PUSH8:
+                                case OpCode.PUSH9:
+                                case OpCode.PUSH10:
+                                case OpCode.PUSH11:
+                                case OpCode.PUSH12:
+                                case OpCode.PUSH13:
+                                case OpCode.PUSH14:
+                                case OpCode.PUSH15:
+                                case OpCode.PUSH16:*/
+
+                                // Control
+                                //case OpCode.NOP:
+
+                                case OpCode.CALL:
+                                case OpCode.JMP:
+                                case OpCode.JMPIF:
+                                case OpCode.JMPIFNOT:
+                                    {
+                                        int offset = reader.ReadInt16();
+                                        //offset = context.InstructionPointer + offset - 3;
+                                        break;
+                                    }
+
+
+                                /*case OpCode.CALL:
+                                    InvocationStack.Push(context.Clone());
+                                    context.InstructionPointer += 2;
+                                    ExecuteOp(OpCode.JMP, CurrentContext);
+                                    break;*/
+
+                                /*case OpCode.RET:
+                                    InvocationStack.Pop().Dispose();
+                                    if (InvocationStack.Count == 0)
+                                        State |= VMState.HALT;
+                                    break;*/
+
+                                case OpCode.APPCALL:
+                                case OpCode.TAILCALL:
+                                    {
+                                        byte[] script_hash = reader.ReadBytes(20);
+                                        entry.data = script_hash;
+                                        entry.comment = "Calls script with hash: $XX";
+                                        break;
+                                    }
+
+                                case OpCode.SYSCALL:
+                                    {
+                                        entry.data = reader.ReadVarBytes(252);
+                                        entry.comment = "System call with data: $$";
+                                        break;
+                                    }
+
+                                // Stack ops
+                                /*case OpCode.DUPFROMALTSTACK:
+                                case OpCode.TOALTSTACK:
+                                case OpCode.FROMALTSTACK:
+                                case OpCode.XDROP:
+                                case OpCode.XSWAP:
+                                case OpCode.XTUCK:
+                                case OpCode.DEPTH:
+                                case OpCode.DROP:
+                                case OpCode.DUP:
+                                case OpCode.NIP:
+                                case OpCode.OVER:
+                                case OpCode.PICK:
+                                case OpCode.ROLL:
+                                case OpCode.ROT:
+                                case OpCode.SWAP:
+                                case OpCode.TUCK:
+                                case OpCode.CAT:
+                                case OpCode.SUBSTR:
+                                case OpCode.LEFT:
+                                case OpCode.RIGHT:
+                                case OpCode.SIZE:
+                                    */
+
+
+                                // Bitwise logic
+                                /*case OpCode.INVERT:
+                                case OpCode.AND:
+                                case OpCode.OR:
+                                case OpCode.XOR:
+                                case OpCode.EQUAL:
+        |                            */
+
+
+
+                                // Numeric
+                                /*case OpCode.INC:
+                                case OpCode.DEC:
+                                case OpCode.SIGN:
+                                case OpCode.NEGATE:
+                                case OpCode.ABS:
+                                case OpCode.NOT:
+                                case OpCode.NZ:
+                                case OpCode.ADD:
+                                case OpCode.SUB:
+                                case OpCode.MUL:
+                                case OpCode.DIV:
+                                case OpCode.MOD:
+                                case OpCode.SHL:
+                                case OpCode.SHR:
+                                case OpCode.BOOLAND:
+                                case OpCode.BOOLOR:
+                                case OpCode.NUMEQUAL:
+                                case OpCode.NUMNOTEQUAL:
+                                case OpCode.LT:
+                                case OpCode.GT:
+                                case OpCode.LTE:
+                                case OpCode.GTE:
+                                case OpCode.MIN:
+                                case OpCode.MAX:
+                                case OpCode.WITHIN:
+                                    */
+
+                                // Crypto
+                                /*
+                                case OpCode.SHA1:
+                                case OpCode.SHA256:
+                                case OpCode.HASH160:
+                                case OpCode.HASH256:
+                                case OpCode.CHECKSIG:
+                                case OpCode.CHECKMULTISIG:
+                                case OpCode.ARRAYSIZE:
+                                case OpCode.PACK:
+                                case OpCode.UNPACK:
+                                case OpCode.PICKITEM:
+                                case OpCode.SETITEM:
+                                case OpCode.NEWARRAY:
+                                case OpCode.NEWSTRUCT:
+                                */
+
+                                // Exceptions
+                                /*case OpCode.THROW:
+                                case OpCode.THROWIFNOT:
+                                */
+
+                                default:
+                                    {
+                                        if (!Enum.IsDefined(typeof(OpCode), opcode))
+                                        {
+                                            var s = ((byte)opcode).ToString();
+                                            throw new DisassembleException("Invalid opcode " + s);
+                                        }
+
+                                        break;
+                                    }
+                            }
+
+                        entry.endOfs = (int)(reader.BaseStream.Position-1);
+                    }
+                }
+            }
+
+            return new AVMDisassemble(output);
+        }
+
+    }
+}

--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -958,12 +958,7 @@ namespace Neo.Compiler.MSIL
                     }
                     break;
                 default:
-#if WITHPDB
-                    logger.Log("unsupported instruction " + src.code + "\r\n   in: " + to.name + "\r\n");
-                    break;
-#else
                     throw new Exception("unsupported instruction " + src.code + "\r\n   in: " + to.name + "\r\n");
-#endif
             }
 
             return skipcount;

--- a/neon/MSIL/ILModule.cs
+++ b/neon/MSIL/ILModule.cs
@@ -19,14 +19,14 @@ namespace Neo.Compiler.MSIL
         public void LoadModule(System.IO.Stream dllStream, System.IO.Stream pdbStream)
         {
             this.module = Mono.Cecil.ModuleDefinition.ReadModule(dllStream);
-#if WITHPDB
+
             if (pdbStream != null)
             {
                 var debugInfoLoader = new Mono.Cecil.Pdb.PdbReaderProvider();
 
                 module.ReadSymbols(debugInfoLoader.GetSymbolReader(module, pdbStream));
             }
-#endif
+
             if (module.HasAssemblyReferences)
             {
                 foreach (var ar in module.AssemblyReferences)

--- a/neon/Program.cs
+++ b/neon/Program.cs
@@ -1,4 +1,4 @@
-﻿using Neo.Compiler.Debug;
+﻿using Neo.Compiler.Debugger;
 using Neo.Compiler.MSIL;
 using System;
 using System.IO;

--- a/neon/RIPEMD160Managed.cs
+++ b/neon/RIPEMD160Managed.cs
@@ -1,5 +1,4 @@
-﻿#if !NET461
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography;
@@ -1051,4 +1050,3 @@ namespace Neo.Cryptography
         }
     }
 }
-#endif

--- a/neon/neon.csproj
+++ b/neon/neon.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AntShares.MonoCecil" Version="1.0.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.9.6.4" />
     <PackageReference Include="Neo.VM" Version="2.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR contains code that generates a "debug map" for an .AVM file.

The debug map format is compatible with the [Neo debugger tools](https://github.com/Relfos/neo-debugger-tools) by City of Zion. The debug map is generated in .json format, containing a mapping of each .AVM instruction offset to the original source code line. The format is language-agnostic, has been tested with C# and Python Neo contracts, plus supports multiple source files. 

This feature is optional (can be toggled by passing --debug flag to neon.exe).