### PR TITLE
Hashing interop names to 4 bytes

### DIFF
--- a/neon/ConvOption.cs
+++ b/neon/ConvOption.cs
@@ -8,7 +8,9 @@ namespace Neo.Compiler
 {
     public class ConvOption
     {
-        public bool useNep8 = false;//將call 升級為callI
+        public bool useNep8 = false;//將call 升級為callI'
+
+        public bool useSysCallInteropHash = false;
         public static ConvOption Default
         {
             get

--- a/neon/Helper.cs
+++ b/neon/Helper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Security.Cryptography;
+
+namespace Neo.Compiler
+{
+    public static class Helper
+    {
+        public static uint ToInteropMethodHash(this string method)
+        {
+            return ToInteropMethodHash(Encoding.ASCII.GetBytes(method));
+        }
+
+        public static uint ToInteropMethodHash(this byte[] method)
+        {
+            using (SHA256 sha = SHA256.Create())
+            {
+                return BitConverter.ToUInt32(sha.ComputeHash(method), 0);
+            }
+        }
+    }
+}

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -765,12 +765,10 @@ namespace Neo.Compiler.MSIL
             {
                 var bytesName = Encoding.UTF8.GetBytes(callname);
                 if (bytesName.Length > 252) throw new Exception("string is too long");
-                byte[] bytes = {0, 0, 0, 0};
+                byte[] bytes;
                 using (SHA256 sha = SHA256.Create())
                 {
-                    var bt32out = sha.ComputeHash(bytesName);
-                    for(var i = 0; i<bytes.Length; i++)
-                        bytes[i] = bt32out[i];
+                    bytes = sha.ComputeHash(bytesName);
                 }
                 byte[] outbytes = new byte[bytes.Length + 1];
                 outbytes[0] = (byte)bytes.Length;

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -763,9 +763,17 @@ namespace Neo.Compiler.MSIL
             }
             else if (calltype == 3)
             {
-                //now neovm use ineropMethod hash for syscall.
-                var bytes = BitConverter.GetBytes( callname.ToInteropMethodHash());
-
+                byte[] bytes = null;
+                if (this.outModule.option.useSysCallInteropHash)
+                {
+                    //now neovm use ineropMethod hash for syscall.
+                    bytes = BitConverter.GetBytes(callname.ToInteropMethodHash());
+                }
+                else
+                {
+                    bytes = System.Text.Encoding.UTF8.GetBytes(callname);
+                    if (bytes.Length > 252) throw new Exception("string is to long");
+                }
                 byte[] outbytes = new byte[bytes.Length + 1];
                 outbytes[0] = (byte)bytes.Length;
                 Array.Copy(bytes, 0, outbytes, 1, bytes.Length);

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -768,7 +768,7 @@ namespace Neo.Compiler.MSIL
                 byte[] bytes;
                 using (SHA256 sha = SHA256.Create())
                 {
-                    bytes = sha.ComputeHash(bytesName);
+                    bytes = sha.ComputeHash(bytesName).Take(4).ToArray();
                 }
                 byte[] outbytes = new byte[bytes.Length + 1];
                 outbytes[0] = (byte)bytes.Length;

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -764,15 +764,13 @@ namespace Neo.Compiler.MSIL
             else if (calltype == 3)
             {
                 var bytesName = Encoding.UTF8.GetBytes(callname);
-                if (bytesName.Length > 252) throw new Exception("string is to long");
-                byte[] bytes = {4, 0, 0, 0, 0};
+                if (bytesName.Length > 252) throw new Exception("string is too long");
+                byte[] bytes = {0, 0, 0, 0};
                 using (SHA256 sha = SHA256.Create())
                 {
                     var bt32out = sha.ComputeHash(method);
-                    bytes[1] = bt32out[0];
-                    bytes[2] = bt32out[1];
-                    bytes[3] = bt32out[2];
-                    bytes[4] = bt32out[3];
+                    for(var i = 0; i<bytes.Length; i++)
+                        bytes[i] = bt32out[i];
                 }
                 byte[] outbytes = new byte[bytes.Length + 1];
                 outbytes[0] = (byte)bytes.Length;

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Security.Cryptography;
 
 namespace Neo.Compiler.MSIL
 {
@@ -762,8 +763,17 @@ namespace Neo.Compiler.MSIL
             }
             else if (calltype == 3)
             {
-                var bytes = Encoding.UTF8.GetBytes(callname);
-                if (bytes.Length > 252) throw new Exception("string is to long");
+                var bytesName = Encoding.UTF8.GetBytes(callname);
+                if (bytesName.Length > 252) throw new Exception("string is to long");
+                byte[] bytes = {4, 0, 0, 0, 0};
+                using (SHA256 sha = SHA256.Create())
+                {
+                    var bt32out = sha.ComputeHash(method);
+                    bytes[1] = bt32out[0];
+                    bytes[2] = bt32out[1];
+                    bytes[3] = bt32out[2];
+                    bytes[4] = bt32out[3];
+                }
                 byte[] outbytes = new byte[bytes.Length + 1];
                 outbytes[0] = (byte)bytes.Length;
                 Array.Copy(bytes, 0, outbytes, 1, bytes.Length);

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -768,7 +768,7 @@ namespace Neo.Compiler.MSIL
                 byte[] bytes = {0, 0, 0, 0};
                 using (SHA256 sha = SHA256.Create())
                 {
-                    var bt32out = sha.ComputeHash(method);
+                    var bt32out = sha.ComputeHash(bytesName);
                     for(var i = 0; i<bytes.Length; i++)
                         bytes[i] = bt32out[i];
                 }

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -763,13 +763,9 @@ namespace Neo.Compiler.MSIL
             }
             else if (calltype == 3)
             {
-                var bytesName = Encoding.UTF8.GetBytes(callname);
-                if (bytesName.Length > 252) throw new Exception("string is too long");
-                byte[] bytes;
-                using (SHA256 sha = SHA256.Create())
-                {
-                    bytes = sha.ComputeHash(bytesName).Take(4).ToArray();
-                }
+                //now neovm use ineropMethod hash for syscall.
+                var bytes = BitConverter.GetBytes( callname.ToInteropMethodHash());
+
                 byte[] outbytes = new byte[bytes.Length + 1];
                 outbytes[0] = (byte)bytes.Length;
                 Array.Copy(bytes, 0, outbytes, 1, bytes.Length);

--- a/neon/Program.cs
+++ b/neon/Program.cs
@@ -45,13 +45,13 @@ namespace Neo.Compiler
             if (filename == null)
             {
                 log.Log("need one param for DLL filename.");
-                log.Log("[--compatible] disable nep8 function");
+                log.Log("[--compatible] disable nep8 function and disable SyscallInteropHash");
                 log.Log("Example:neon abc.dll --compatible");
                 return;
             }
             if (bCompatible)
             {
-                log.Log("use --compatible no nep8");
+                log.Log("use --compatible no nep8 and no SyscallInteropHash");
             }
             string onlyname = System.IO.Path.GetFileNameWithoutExtension(filename);
             string filepdb = onlyname + ".pdb";
@@ -108,6 +108,7 @@ namespace Neo.Compiler
                 var conv = new ModuleConverter(log);
                 ConvOption option = new ConvOption();
                 option.useNep8 = !bCompatible;
+                option.useSysCallInteropHash = !bCompatible;
                 NeoModule am = conv.Convert(mod, option);
                 bytes = am.Build();
                 log.Log("convert succ");


### PR DESCRIPTION
This is a first approach to start hashing names to 4 bytes only.

Still needs more testing, to verify if neo-vm output is the same, according to https://github.com/neo-project/neo-vm/pull/61.