### PR TITLE
Allowing sbyte[] initialization

### DIFF
--- a/neon/MSIL/CctorSubVM.cs
+++ b/neon/MSIL/CctorSubVM.cs
@@ -99,7 +99,7 @@ namespace Neo.Compiler.MSIL
                         break;
                     case CodeEx.Newarr:
                         {
-                            if (src.tokenType == "System.Byte")
+                            if ((src.tokenType == "System.Byte") || (src.tokenType == "System.SByte"))
                             {
                                 var count = (int)calcStack.Pop();
                                 byte[] data = new byte[count];

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -690,7 +690,7 @@ namespace Neo.Compiler.MSIL
             bool havethis = md.HasThis;
             if (calltype == 2)
             {
-                //opcode call 
+                //opcode call
             }
             else
             {//翻转参数顺序
@@ -912,7 +912,7 @@ namespace Neo.Compiler.MSIL
         private int _ConvertNewArr(ILMethod method, OpCode src, NeoMethod to)
         {
             var type = src.tokenType;
-            if (type != "System.Byte")
+            if ((type != "System.Byte") && (type != "System.SByte"))
             {
                 _Convert1by1(VM.OpCode.NEWARRAY, src, to);
                 int n = method.GetNextCodeAddr(src.addr);
@@ -933,13 +933,13 @@ namespace Neo.Compiler.MSIL
                         }
                         return 3;
                     }
-                    throw new Exception("not support this type's init array.");
+                    throw new Exception($"not support this type's init array. type: {type}");
 
                 }
                 return 0;
                 //this.logger.Log("_ConvertNewArr::not support type " + type + " for array.");
             }
-            else
+            else // (type == "System.Byte") || (type == "System.SByte")
             {
                 var code = to.body_Codes.Last().Value;
                 //we need a number
@@ -961,9 +961,13 @@ namespace Neo.Compiler.MSIL
                 int n2 = method.GetNextCodeAddr(n);
                 int n3 = method.GetNextCodeAddr(n2);
                 int n4 = method.GetNextCodeAddr(n3);
-                if (n >= 0 && n2 >= 0 && n3 >= 0 && method.body_Codes[n].code == CodeEx.Dup && method.body_Codes[n2].code == CodeEx.Ldtoken && method.body_Codes[n3].code == CodeEx.Call)
-                {//這是在初始化數組
 
+                if (n >= 0 && n2 >= 0 && n3 >= 0 && method.body_Codes[n].code == CodeEx.Dup && method.body_Codes[n2].code == CodeEx.Ldtoken && method.body_Codes[n3].code == CodeEx.Call)
+                {
+                    // 這是在初始化數組
+                    // en: this is the initialization array
+
+                    // System.Byte or System.SByte
                     var data = method.body_Codes[n2].tokenUnknown as byte[];
                     this._ConvertPush(data, src, to);
 
@@ -1190,7 +1194,7 @@ namespace Neo.Compiler.MSIL
             //_Convert1by1(VM.OpCode.CLONESTRUCTONLY, src, to);
 
             _ConvertPush(id, null, to);//index
-            _Convert1by1(VM.OpCode.SWAP, null, to);//把item 拿上來 
+            _Convert1by1(VM.OpCode.SWAP, null, to);//把item 拿上來
 
             _Convert1by1(VM.OpCode.SETITEM, null, to);//修改值 //item //index //array
             return 0;

--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -333,7 +333,7 @@ namespace Neo.Compiler.MSIL
                 else
                 {
                     //在return之前加入清理参数代码
-                    if (src.code == CodeEx.Ret)//before return 
+                    if (src.code == CodeEx.Ret)//before return
                     {
                         _insertEndCode(from, to, src);
                     }
@@ -781,13 +781,21 @@ namespace Neo.Compiler.MSIL
 
 
                 //array
-                case CodeEx.Ldelem_U1://用意为byte[] 取一部分.....
+                //用意为byte[] 取一部分.....
+                // en: intent to use byte[] as array.....
+                case CodeEx.Ldelem_U1:
+                    _ConvertPush(1, src, to);
+                    _Convert1by1(VM.OpCode.SUBSTR, null, to);
+                    break;
+                //用意为sbyte[] 取一部分.....
+                // en: intent to use sbyte[] as array.....
+                case CodeEx.Ldelem_I1:
                     _ConvertPush(1, src, to);
                     _Convert1by1(VM.OpCode.SUBSTR, null, to);
                     break;
                 case CodeEx.Ldelem_Any:
                 case CodeEx.Ldelem_I:
-                case CodeEx.Ldelem_I1:
+                //case CodeEx.Ldelem_I1:
                 case CodeEx.Ldelem_I2:
                 case CodeEx.Ldelem_I4:
                 case CodeEx.Ldelem_I8:


### PR DESCRIPTION
This code:
```cs
sbyte[] b2 = new sbyte[]{0, 1, 10, 127, -100};
```
will issue: PUSHBYTES5 00010a7f9c

Trying to use offlimit values will fail naturally:
sbyte[] b2 = new sbyte[]{255}; // won't compile