### PR TITLE
Fixed byte[] attribution for general case

### DIFF
--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -15,9 +15,11 @@ namespace Neo.Compiler.MSIL
         {
 
             //get array
-            _Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
-            _Convert1by1(VM.OpCode.DUP, null, to);
-            _Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            //_Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
+            //_Convert1by1(VM.OpCode.DUP, null, to);
+            //_Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            _Convert1by1(VM.OpCode.DUPFROMALTSTACK, src, to);
+
             //get i
             _ConvertPush(pos + method.paramtypes.Count, null, to);//翻转取参数顺序
 
@@ -61,9 +63,10 @@ namespace Neo.Compiler.MSIL
         private void _ConvertLdLoc(ILMethod method, OpCode src, NeoMethod to, int pos)
         {
             //get array
-            _Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
-            _Convert1by1(VM.OpCode.DUP, null, to);
-            _Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            //_Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
+            //_Convert1by1(VM.OpCode.DUP, null, to);
+            //_Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            _Convert1by1(VM.OpCode.DUPFROMALTSTACK, src, to);
             //get i
             _ConvertPush(pos + method.paramtypes.Count, null, to);//翻转取参数顺序
             _Convert1by1(VM.OpCode.PICKITEM, null, to);
@@ -138,9 +141,10 @@ namespace Neo.Compiler.MSIL
             }
             //}
             //get array
-            _Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
-            _Convert1by1(VM.OpCode.DUP, null, to);
-            _Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            //_Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
+            //_Convert1by1(VM.OpCode.DUP, null, to);
+            //_Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            _Convert1by1(VM.OpCode.DUPFROMALTSTACK, src, to);
             //get i
             _ConvertPush(pos, null, to);//翻转取参数顺序
             _Convert1by1(VM.OpCode.PICKITEM, null, to);
@@ -1102,9 +1106,10 @@ namespace Neo.Compiler.MSIL
             //now stack  a index, a value
 
             //getarray
-            _Insert1(VM.OpCode.FROMALTSTACK, null, to);
-            _Insert1(VM.OpCode.DUP, null, to);
-            _Insert1(VM.OpCode.TOALTSTACK, null, to);
+            //_Convert1by1(VM.OpCode.FROMALTSTACK, null, to);
+            //_Convert1by1(VM.OpCode.DUP, null, to);
+            //_Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            _Convert1by1(VM.OpCode.DUPFROMALTSTACK, null, to);
 
             _InsertPush(2, "", to);//move item
             _Insert1(VM.OpCode.ROLL, null, to);

--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -809,9 +809,74 @@ namespace Neo.Compiler.MSIL
                 case CodeEx.Ldlen:
                     _Convert1by1(VM.OpCode.ARRAYSIZE, src, to);
                     break;
+
+                case CodeEx.Stelem_I1:
+                      {
+                        // WILL TRACE VARIABLE ORIGIN "Z" IN ALTSTACK!
+                        // EXPECTS:  source[index] = b; // index and b must be variables! constants will fail!
+                        /*
+                        9 6a DUPFROMALTSTACK
+                        8 5Z PUSHZ
+                        7 c3 PICKITEM
+                        6 6a DUPFROMALTSTACK
+                        5 5Y PUSHY
+                        4 c3 PICKITEM
+                        3 6a DUPFROMALTSTACK
+                        2 5X PUSHX
+                        1 c3 PICKITEM
+                        */
+
+                        if(  (to.body_Codes[addr-1].code == VM.OpCode.PICKITEM)
+                          && (to.body_Codes[addr-4].code == VM.OpCode.PICKITEM)
+                          && (to.body_Codes[addr-7].code == VM.OpCode.PICKITEM)
+                          && (to.body_Codes[addr-3].code == VM.OpCode.DUPFROMALTSTACK)
+                          && (to.body_Codes[addr-6].code == VM.OpCode.DUPFROMALTSTACK)
+                          && (to.body_Codes[addr-9].code == VM.OpCode.DUPFROMALTSTACK)
+                          && ((to.body_Codes[addr-2].code >= VM.OpCode.PUSH0) && (to.body_Codes[addr-2].code <= VM.OpCode.PUSH16))
+                          && ((to.body_Codes[addr-5].code >= VM.OpCode.PUSH0) && (to.body_Codes[addr-5].code <= VM.OpCode.PUSH16))
+                          && ((to.body_Codes[addr-8].code >= VM.OpCode.PUSH0) && (to.body_Codes[addr-8].code <= VM.OpCode.PUSH16))
+                          )
+                          {
+                              // WILL REQUIRE TO PROCESS INFORMATION AND STORE IT AGAIN ON ALTSTACK CORRECT POSITION
+                              VM.OpCode PushZ = to.body_Codes[addr-8].code;
+
+                              _Convert1by1(VM.OpCode.PUSH2, null, to);
+                              _Convert1by1(VM.OpCode.PICK, null, to);
+                              _Convert1by1(VM.OpCode.PUSH2, null, to);
+                              _Convert1by1(VM.OpCode.PICK, null, to);
+                              _Convert1by1(VM.OpCode.LEFT, null, to);
+                              _Convert1by1(VM.OpCode.SWAP, null, to);
+                              _Convert1by1(VM.OpCode.CAT, null, to);
+                              _Convert1by1(VM.OpCode.ROT, null, to);
+                              _Convert1by1(VM.OpCode.ROT, null, to);
+                              _Convert1by1(VM.OpCode.OVER, null, to);
+                              _Convert1by1(VM.OpCode.ARRAYSIZE, null, to);
+                              _Convert1by1(VM.OpCode.DEC, null, to);
+                              _Convert1by1(VM.OpCode.SWAP, null, to);
+                              _Convert1by1(VM.OpCode.SUB, null, to);
+                              _Convert1by1(VM.OpCode.RIGHT, null, to);
+                              _Convert1by1(VM.OpCode.CAT, null, to);
+
+                              // FINAL RESULT MUST GO BACK TO POSITION Z ON ALTSTACK
+
+                              // FINAL STACK:
+                              // 4 get array (dupfromaltstack)
+                              // 3 PushZ
+                              // 2 result
+                              // 1 setitem
+
+                              _Convert1by1(VM.OpCode.DUPFROMALTSTACK, null, to);  // stack: [ array , result , ... ]
+                              _Convert1by1(PushZ, null, to);                      // stack: [ pushz, array , result , ... ]
+                              _Convert1by1(VM.OpCode.ROT, null, to);              // stack: [ result, pushz, array , ... ]
+                              _Convert1by1(VM.OpCode.SETITEM, null, to);          // stack: [ result, pushz, array , ... ]
+                          }
+                          else
+                              throw new Exception("neomachine currently supports only variable indexed bytearray attribution, example: byte[] source; int index = 0; byte b = 1; source[index] = b;");
+                      } // end case
+                      break;
                 case CodeEx.Stelem_Any:
                 case CodeEx.Stelem_I:
-                case CodeEx.Stelem_I1:
+                //case CodeEx.Stelem_I1:
                 case CodeEx.Stelem_I2:
                 case CodeEx.Stelem_I4:
                 case CodeEx.Stelem_I8:


### PR DESCRIPTION
Finally, managed to solve byte[] attribution, at least on the general case.

General case is when attribution and index are both variables (not constant for now).
Working example:
```cs
        public static byte[] Main(byte[] v)
        {
            int i = 2;
            byte j = 5;
            v[i] = j;
            return v;
        }
```