### PR TITLE
Inline attribute to mix opcode/syscalls

### DIFF
--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -186,10 +186,10 @@ namespace Neo.Compiler.MSIL
             _Convert1by1(VM.OpCode.SETITEM, null, to);
         }
 
-        public bool IsInlineCall(Mono.Cecil.MethodDefinition defs, out VM.OpCode[] opcodes, out string[] names, out bool[] isHex)
+        public bool IsInlineCall(Mono.Cecil.MethodDefinition defs, out VM.OpCode[] opcodes, out string[] opdata, out bool[] isHex)
         {
             opcodes = null;
-            names = null;
+            opdata = null;
             isHex = null;
 
             if (defs == null)
@@ -204,7 +204,7 @@ namespace Neo.Compiler.MSIL
             }
 
             opcodes = new VM.OpCode[defs.CustomAttributes.Count];
-            names   = new string[defs.CustomAttributes.Count];
+            opdata  = new string[defs.CustomAttributes.Count];
             isHex   = new bool[defs.CustomAttributes.Count];
 
             int i = 0;
@@ -214,16 +214,16 @@ namespace Neo.Compiler.MSIL
                 if (attr.AttributeType.Name == "InlineAttribute")
                 {
                     opcodes[i] = (VM.OpCode)attr.ConstructorArguments[0].Value;
-                    names[i] = (string)attr.ConstructorArguments[1].Value;
+                    opdata[i] = (string)attr.ConstructorArguments[1].Value;
                     isHex[i] = (bool) attr.ConstructorArguments[2].Value;
 
-                    if((names[i] != "") && (opcodes[i] != VM.OpCode.SYSCALL))
+                    if((opdata[i] != "") && (opcodes[i] != VM.OpCode.SYSCALL))
                     {
                         throw new Exception("neomachine Inline currently supports extensions only for SYSCALL opcode!");
                         return false;
                     }
 
-                    if((opcodes[i] == VM.OpCode.SYSCALL) && (isHex[i] || (names[i] == "")))
+                    if((opcodes[i] == VM.OpCode.SYSCALL) && (isHex[i] || (opdata[i] == "")))
                     {
                         throw new Exception("neomachine Inline currently supports SYSCALL only with plain non-empty text (not hex)!");
                         return false;
@@ -240,7 +240,7 @@ namespace Neo.Compiler.MSIL
             }
 
             opcodes = null;
-            names = null;
+            opdata = null;
             isHex = null;
 
             if(i > 0)

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -15,9 +15,11 @@ namespace Neo.Compiler.MSIL
         {
 
             //get array
-            _Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
-            _Convert1by1(VM.OpCode.DUP, null, to);
-            _Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            //_Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
+            //_Convert1by1(VM.OpCode.DUP, null, to);
+            //_Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            _Convert1by1(VM.OpCode.DUPFROMALTSTACK, src, to);
+
             //get i
             _ConvertPush(pos + method.paramtypes.Count, null, to);//翻转取参数顺序
 
@@ -61,9 +63,10 @@ namespace Neo.Compiler.MSIL
         private void _ConvertLdLoc(ILMethod method, OpCode src, NeoMethod to, int pos)
         {
             //get array
-            _Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
-            _Convert1by1(VM.OpCode.DUP, null, to);
-            _Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            //_Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
+            //_Convert1by1(VM.OpCode.DUP, null, to);
+            //_Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            _Convert1by1(VM.OpCode.DUPFROMALTSTACK, src, to);
             //get i
             _ConvertPush(pos + method.paramtypes.Count, null, to);//翻转取参数顺序
             _Convert1by1(VM.OpCode.PICKITEM, null, to);
@@ -138,9 +141,10 @@ namespace Neo.Compiler.MSIL
             }
             //}
             //get array
-            _Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
-            _Convert1by1(VM.OpCode.DUP, null, to);
-            _Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            //_Convert1by1(VM.OpCode.FROMALTSTACK, src, to);
+            //_Convert1by1(VM.OpCode.DUP, null, to);
+            //_Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            _Convert1by1(VM.OpCode.DUPFROMALTSTACK, src, to);
             //get i
             _ConvertPush(pos, null, to);//翻转取参数顺序
             _Convert1by1(VM.OpCode.PICKITEM, null, to);
@@ -1102,9 +1106,10 @@ namespace Neo.Compiler.MSIL
             //now stack  a index, a value
 
             //getarray
-            _Insert1(VM.OpCode.FROMALTSTACK, null, to);
-            _Insert1(VM.OpCode.DUP, null, to);
-            _Insert1(VM.OpCode.TOALTSTACK, null, to);
+            //_Convert1by1(VM.OpCode.FROMALTSTACK, null, to);
+            //_Convert1by1(VM.OpCode.DUP, null, to);
+            //_Convert1by1(VM.OpCode.TOALTSTACK, null, to);
+            _Convert1by1(VM.OpCode.DUPFROMALTSTACK, null, to);
 
             _InsertPush(2, "", to);//move item
             _Insert1(VM.OpCode.ROLL, null, to);

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -206,7 +206,7 @@ namespace Neo.Compiler.MSIL
             opcodes = new VM.OpCode[defs.CustomAttributes.Count];
             names   = new string[defs.CustomAttributes.Count];
             isHex   = new bool[defs.CustomAttributes.Count];
-            
+
             int i = 0;
 
             foreach (var attr in defs.CustomAttributes)
@@ -246,7 +246,7 @@ namespace Neo.Compiler.MSIL
             if(i > 0)
             {
                 // InlineAttribute together with different attribute, cannot mix!
-                throw new Exception("Cannot mix Inline attribute with others!");
+                throw new Exception("neomachine Cannot mix Inline attribute with others!");
             }
 
             return false;

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -199,12 +199,14 @@ namespace Neo.Compiler.MSIL
 
             if(defs.CustomAttributes.Count == 0)
             {
+                // no InlineAttribute
                 return false;
             }
 
             opcodes = new VM.OpCode[defs.CustomAttributes.Count];
             names   = new string[defs.CustomAttributes.Count];
             isHex   = new bool[defs.CustomAttributes.Count];
+            
             int i = 0;
 
             foreach (var attr in defs.CustomAttributes)
@@ -229,17 +231,25 @@ namespace Neo.Compiler.MSIL
 
                     i++;
                 }
-                else
-                {
-                    // different attribute, cannot mix!
-                    opcodes = null;
-                    names = null;
-                    isHex = null;
-                    throw new Exception("Cannot mix Inline attribute with others!");
-                    return false;
-                }
             }
-            return true;
+
+            if(i == defs.CustomAttributes.Count)
+            {
+                // all attributes are InlineAttribute
+                return true;
+            }
+
+            opcodes = null;
+            names = null;
+            isHex = null;
+
+            if(i > 0)
+            {
+                // InlineAttribute together with different attribute, cannot mix!
+                throw new Exception("Cannot mix Inline attribute with others!");
+            }
+
+            return false;
         }
 
 

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -448,7 +448,7 @@ namespace Neo.Compiler.MSIL
             byte[] callhash = null;
             VM.OpCode callcode = VM.OpCode.NOP;
             VM.OpCode[] callcodes = null;
-            string[] callnames = null;
+            string[] calldata = null;
             bool[] isHex = null;
 
             Mono.Cecil.MethodDefinition defs = null;
@@ -496,7 +496,7 @@ namespace Neo.Compiler.MSIL
             {
                 calltype = 3;
             }
-            else if (IsInlineCall(defs, out callcodes, out callnames, out isHex))
+            else if (IsInlineCall(defs, out callcodes, out calldata, out isHex))
             {
                 calltype = 7;
             }
@@ -870,11 +870,11 @@ namespace Neo.Compiler.MSIL
                         if (this.outModule.option.useSysCallInteropHash)
                         {
                             //now neovm use ineropMethod hash for syscall.
-                            bytes = BitConverter.GetBytes(callnames[j].ToInteropMethodHash());
+                            bytes = BitConverter.GetBytes(calldata[j].ToInteropMethodHash());
                         }
                         else
                         {
-                            bytes = System.Text.Encoding.UTF8.GetBytes(callnames[j]);
+                            bytes = System.Text.Encoding.UTF8.GetBytes(calldata[j]);
                             if (bytes.Length > 252) throw new Exception("string is to long");
                         }
                         byte[] outbytes = new byte[bytes.Length + 1];

--- a/neon/MSIL/Conv_Multi.cs
+++ b/neon/MSIL/Conv_Multi.cs
@@ -886,6 +886,7 @@ namespace Neo.Compiler.MSIL
                     else
                     {
                         _Convert1by1(callcodes[j], src, to);
+                        // TODO: consider calldata[j] for other opcodes (PUSHDATA2, etc...) using isHex (example: "01ab" ...)
                     }
                 }
                 return 0;

--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -172,12 +172,12 @@ namespace Neo.Compiler.MSIL
                         }
 
                         byte[] outcall; string name; VM.OpCode[] opcodes;
-                        string[] extension; bool[] isHex;
+                        string[] opdata; bool[] isHex;
                         if (IsAppCall(m.Value.method, out outcall))
                             continue;
                         if (IsNonCall(m.Value.method))
                             continue;
-                        if (IsInlineCall(m.Value.method, out opcodes, out extension, out isHex))
+                        if (IsInlineCall(m.Value.method, out opcodes, out opdata, out isHex))
                             continue;
                         if (IsOpCall(m.Value.method, out opcodes))
                             continue;

--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -177,11 +177,11 @@ namespace Neo.Compiler.MSIL
                             continue;
                         if (IsNonCall(m.Value.method))
                             continue;
+                        if (IsInlineCall(m.Value.method, out opcodes, out extension, out isHex))
+                            continue;
                         if (IsOpCall(m.Value.method, out opcodes))
                             continue;
                         if (IsSysCall(m.Value.method, out name))
-                            continue;
-                        if (IsInlineCall(m.Value.method, out opcodes, out extension, out isHex))
                             continue;
 
                         this.ConvertMethod(m.Value, nm);

--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -809,9 +809,74 @@ namespace Neo.Compiler.MSIL
                 case CodeEx.Ldlen:
                     _Convert1by1(VM.OpCode.ARRAYSIZE, src, to);
                     break;
+
+                case CodeEx.Stelem_I1:
+                      {
+                        // WILL TRACE VARIABLE ORIGIN "Z" IN ALTSTACK!
+                        // EXPECTS:  source[index] = b; // index and b must be variables! constants will fail!
+                        /*
+                        9 6a DUPFROMALTSTACK
+                        8 5Z PUSHZ
+                        7 c3 PICKITEM
+                        6 6a DUPFROMALTSTACK
+                        5 5Y PUSHY
+                        4 c3 PICKITEM
+                        3 6a DUPFROMALTSTACK
+                        2 5X PUSHX
+                        1 c3 PICKITEM
+                        */
+
+                        if(  (to.body_Codes[addr-1].code == VM.OpCode.PICKITEM)
+                          && (to.body_Codes[addr-4].code == VM.OpCode.PICKITEM)
+                          && (to.body_Codes[addr-7].code == VM.OpCode.PICKITEM)
+                          && (to.body_Codes[addr-3].code == VM.OpCode.DUPFROMALTSTACK)
+                          && (to.body_Codes[addr-6].code == VM.OpCode.DUPFROMALTSTACK)
+                          && (to.body_Codes[addr-9].code == VM.OpCode.DUPFROMALTSTACK)
+                          && ((to.body_Codes[addr-2].code >= VM.OpCode.PUSH0) && (to.body_Codes[addr-2].code <= VM.OpCode.PUSH16))
+                          && ((to.body_Codes[addr-5].code >= VM.OpCode.PUSH0) && (to.body_Codes[addr-5].code <= VM.OpCode.PUSH16))
+                          && ((to.body_Codes[addr-8].code >= VM.OpCode.PUSH0) && (to.body_Codes[addr-8].code <= VM.OpCode.PUSH16))
+                          )
+                          {
+                              // WILL REQUIRE TO PROCESS INFORMATION AND STORE IT AGAIN ON ALTSTACK CORRECT POSITION
+                              VM.OpCode PushZ = to.body_Codes[addr-8].code;
+
+                              _Convert1by1(VM.OpCode.PUSH2, null, to);
+                              _Convert1by1(VM.OpCode.PICK, null, to);
+                              _Convert1by1(VM.OpCode.PUSH2, null, to);
+                              _Convert1by1(VM.OpCode.PICK, null, to);
+                              _Convert1by1(VM.OpCode.LEFT, null, to);
+                              _Convert1by1(VM.OpCode.SWAP, null, to);
+                              _Convert1by1(VM.OpCode.CAT, null, to);
+                              _Convert1by1(VM.OpCode.ROT, null, to);
+                              _Convert1by1(VM.OpCode.ROT, null, to);
+                              _Convert1by1(VM.OpCode.OVER, null, to);
+                              _Convert1by1(VM.OpCode.ARRAYSIZE, null, to);
+                              _Convert1by1(VM.OpCode.DEC, null, to);
+                              _Convert1by1(VM.OpCode.SWAP, null, to);
+                              _Convert1by1(VM.OpCode.SUB, null, to);
+                              _Convert1by1(VM.OpCode.RIGHT, null, to);
+                              _Convert1by1(VM.OpCode.CAT, null, to);
+
+                              // FINAL RESULT MUST GO BACK TO POSITION Z ON ALTSTACK
+
+                              // FINAL STACK:
+                              // 4 get array (dupfromaltstack)
+                              // 3 PushZ
+                              // 2 result
+                              // 1 setitem
+
+                              _Convert1by1(VM.OpCode.DUPFROMALTSTACK, null, to);  // stack: [ array , result , ... ]
+                              _Convert1by1(PushZ, null, to);                      // stack: [ pushz, array , result , ... ]
+                              _Convert1by1(VM.OpCode.ROT, null, to);              // stack: [ result, pushz, array , ... ]
+                              _Convert1by1(VM.OpCode.SETITEM, null, to);          // stack: [ result, pushz, array , ... ]
+                          }
+                          else
+                              throw new Exception("neomachine currently supports only variable indexed bytearray attribution, example: byte[] source; int index = 0; byte b = 1; source[index] = b;");
+                      } // end case
+                      break;
                 case CodeEx.Stelem_Any:
                 case CodeEx.Stelem_I:
-                case CodeEx.Stelem_I1:
+                //case CodeEx.Stelem_I1:
                 case CodeEx.Stelem_I2:
                 case CodeEx.Stelem_I4:
                 case CodeEx.Stelem_I8:

--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -173,8 +173,6 @@ namespace Neo.Compiler.MSIL
 
                         byte[] outcall; string name; VM.OpCode[] opcodes;
                         string[] extension; bool[] isHex;
-                        if (IsInlineCall(m.Value.method, out opcodes, out extension, out isHex))
-                            continue;
                         if (IsAppCall(m.Value.method, out outcall))
                             continue;
                         if (IsNonCall(m.Value.method))
@@ -182,6 +180,8 @@ namespace Neo.Compiler.MSIL
                         if (IsOpCall(m.Value.method, out opcodes))
                             continue;
                         if (IsSysCall(m.Value.method, out name))
+                            continue;
+                        if (IsInlineCall(m.Value.method, out opcodes, out extension, out isHex))
                             continue;
 
                         this.ConvertMethod(m.Value, nm);

--- a/neon/MSIL/Converter.cs
+++ b/neon/MSIL/Converter.cs
@@ -172,6 +172,9 @@ namespace Neo.Compiler.MSIL
                         }
 
                         byte[] outcall; string name; VM.OpCode[] opcodes;
+                        string[] extension; bool[] isHex;
+                        if (IsInlineCall(m.Value.method, out opcodes, out extension, out isHex))
+                            continue;
                         if (IsAppCall(m.Value.method, out outcall))
                             continue;
                         if (IsNonCall(m.Value.method))


### PR DESCRIPTION
Example:
```cs
        [Inline(OpCode.SYSCALL, "GetBlockHeight")]
        [Inline(OpCode.INC)]
        public extern static int BlockPlus1();
```